### PR TITLE
removed conditional comparing params.id and session id

### DIFF
--- a/utils/auth.js
+++ b/utils/auth.js
@@ -2,8 +2,6 @@ const withAuth = (req, res, next) => {
   // If the user isn't logged in, redirect them to the login route
   if (!req.session.logged_in) {
     res.redirect('/login');
-  } else if (req.params.id && req.params.id != req.session.user_id) {
-    res.status(400).json({message: "You cannot modify other user's account"})
   } else {
     next();
   }


### PR DESCRIPTION
withAuth function compared req.params.id with req.session.id in order to proceed.  This would cause a bug in comment and post routes where the ":id" parameter referred to post.id or comment.id.